### PR TITLE
Use pypi tar and remove m2crypto as dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - setup.py.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win32 or py3k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: salt-{{ version }}.tar.gz
-  url: https://github.com/saltstack/salt/archive/v{{ version }}.tar.gz
-  sha256: 5cb7460741f44db445baf56e88acb5921e43dbefd5a8c24496f9b78718d96094
+  url: https://pypi.io/packages/source/s/salt/salt-{{ version }}.tar.gz
+  sha256: e316dd103b7faeaa97820197e4d0d7d358519f0ca2a6dcb1d9b718eea801ed30
 
   patches:
     - setup.py.patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - msgpack-python
     - openssl 1.0.*
     - pycrypto
-    - m2crypto
     - pyyaml
     - pyzmq >=2.2.0
     - markupsafe


### PR DESCRIPTION
Fixes https://github.com/conda-forge/salt-feedstock/issues/3 and removes m2crypto since its not needed in newer versions.